### PR TITLE
don't cache provider for web wallet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,11 +16,12 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  ignorePatterns: ['node_modules', 'build', '*-build', '*.json'],
+  ignorePatterns: ['node_modules', 'build', '*-build', '*.json', '!*'],
   rules: {
     'no-unused-vars': ['warn', { vars: 'all', args: 'after-used', argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     'no-console': 'warn',
     'no-shadow': 'warn',
+    'ignored-by-default': 0,
     '@typescript-eslint/no-unused-vars': [
       'warn',
       { vars: 'all', args: 'after-used', argsIgnorePattern: '^_', varsIgnorePattern: '^_' },

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ buck-out/
 web-build/
 data/
 .runtimeconfig.json
+*.log

--- a/.lint-staged.config.js
+++ b/.lint-staged.config.js
@@ -1,9 +1,4 @@
 module.exports = {
-  "drop_*/**/*.{js,jsx,ts,tsx}": [
-    "prettier --write",
-    "eslint --fix --max-warnings 0",
-  ],
-  "drop_avatars/app/**/*.{js,jsx,ts,tsx}": [
-    () => "bash -c 'cd drop_avatars/app && tsc'",
-  ]
+  '**/*.{js,jsx,ts,tsx}': ['prettier --write', 'eslint --fix --max-warnings 0'],
+  'app/**/*.{js,jsx,ts,tsx}': [() => "bash -c 'cd app && tsc'"],
 };

--- a/app/src/WalletProvider.tsx
+++ b/app/src/WalletProvider.tsx
@@ -52,7 +52,7 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
   useEffect(() => {
     if (Platform.OS === 'web') {
       web3Modal = new Web3Modal({
-        cacheProvider: true,
+        cacheProvider: false,
         providerOptions: {
           walletconnect: {
             package: WalletConnectProvider,


### PR DESCRIPTION
Previously, we cached the provider for the desktop web wallet connection flow, which confused users who chose the wrong option the first time connecting. This asks explicitly now each time they connect what method they'd like to use.