### PR TITLE
fix Origin tag in arweave mutable uploads

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -197,7 +197,7 @@ export const setAvatar = functions.https.onCall(async (data, context) => {
 
     // The Origin tag allows us to support "mutable" records, a draft spec being worked on with Arweave team
     if (userData.avatarProtocol === 'arweave') {
-      transaction.addTag('Origin', userData.avatarId);
+      transaction.addTag('Origin', context.auth.uid);
     }
 
     await arweave.transactions.sign(transaction, ARWEAVE_KEY);


### PR DESCRIPTION
Fixes a typo that is preventing arweave-based mutable uploads from properly being picked up by ENS avatar libraries.