### PR TITLE
improve opensea error handling

### DIFF
--- a/app/src/NFTSelectorCloudPure.tsx
+++ b/app/src/NFTSelectorCloudPure.tsx
@@ -1,18 +1,17 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View, Image, TouchableOpacity } from 'react-native';
 
-import { useWallet } from './WalletProvider';
+import { OpenSeaNFT } from './WalletProvider';
 
 const SUPPORTED_ERCS = ['ERC721', 'ERC1155'];
 
 export interface Props {
   selectedIndex?: number | null;
   onSelect?: (_id: string, _image: string, _index: number) => void;
+  nfts: OpenSeaNFT[];
 }
 
-export default function NFTSelectorCloud({ selectedIndex, onSelect }: Props) {
-  const { loadingNfts, nfts } = useWallet();
-
+export default function NFTSelectorCloud({ selectedIndex, onSelect, nfts }: Props) {
   const setSelected = useCallback(
     (index: number) => {
       return async () => {
@@ -32,7 +31,7 @@ export default function NFTSelectorCloud({ selectedIndex, onSelect }: Props) {
   return (
     <View>
       <View style={styles.NFTContainerRow}>
-        {!loadingNfts && nfts && (
+        {nfts && (
           <>
             {nfts
               .filter(nft => SUPPORTED_ERCS.includes(nft.asset_contract.schema_name) && !nft.animation_url)

--- a/app/src/WalletProvider.tsx
+++ b/app/src/WalletProvider.tsx
@@ -34,8 +34,7 @@ export interface Context {
   signMessage: (_message: string, _wallet?: Web3) => Promise<string>;
   loadingWallet: boolean;
   loadingNfts: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  openseaError: any;
+  error?: string;
 }
 
 const WalletContext = createContext<Context>(null!);
@@ -53,7 +52,7 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
   const [isWalletConnect, setIsWalletConnect] = useState(false);
   const [signingExplanationOpen, setSigningExplanationOpen] = useState(false);
   const [loadingNfts, setLoadingNfts] = useState(false);
-  const [openseaError, setOpenseaError] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (Platform.OS === 'web') {
@@ -117,10 +116,11 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
           .then(data => {
             if (data && data.assets) {
               setNfts(data.assets);
+              setError(undefined);
             }
           })
-          .catch(e => {
-            setOpenseaError(e);
+          .catch(() => {
+            setError('Unable to search wallet using OpenSea for NFTs.');
           })
           .finally(() => setLoadingNfts(false));
 
@@ -202,7 +202,7 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
         walletName,
         loadingWallet,
         loadingNfts,
-        openseaError,
+        error,
       }}
     >
       {props.children}

--- a/app/src/WalletProvider.tsx
+++ b/app/src/WalletProvider.tsx
@@ -34,6 +34,8 @@ export interface Context {
   signMessage: (_message: string, _wallet?: Web3) => Promise<string>;
   loadingWallet: boolean;
   loadingNfts: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  openseaError: any;
 }
 
 const WalletContext = createContext<Context>(null!);
@@ -51,6 +53,7 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
   const [isWalletConnect, setIsWalletConnect] = useState(false);
   const [signingExplanationOpen, setSigningExplanationOpen] = useState(false);
   const [loadingNfts, setLoadingNfts] = useState(false);
+  const [openseaError, setOpenseaError] = useState(false);
 
   useEffect(() => {
     if (Platform.OS === 'web') {
@@ -115,6 +118,9 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
             if (data && data.assets) {
               setNfts(data.assets);
             }
+          })
+          .catch(e => {
+            setOpenseaError(e);
           })
           .finally(() => setLoadingNfts(false));
 
@@ -196,6 +202,7 @@ function WalletProvider(props: React.PropsWithChildren<Record<string, never>>) {
         walletName,
         loadingWallet,
         loadingNfts,
+        openseaError,
       }}
     >
       {props.children}

--- a/app/src/screens/SelectNFTSection.tsx
+++ b/app/src/screens/SelectNFTSection.tsx
@@ -18,7 +18,7 @@ export default function SelectNFTSection() {
   const isMoWeb = useIsMoWeb();
   const [avatar, setAvatar] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
-  const { address, loadingNfts, nfts, openseaError } = useWallet();
+  const { address, loadingNfts, nfts, error } = useWallet();
   const { user } = useUser();
   const { name, setAvatar: setEnsAvatar } = useENS();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,8 +72,8 @@ export default function SelectNFTSection() {
 
           <View style={[styles.spaced, isMoWeb && styles.spacedXS]}>
             {loadingNfts && <ActivityIndicator size={24} />}
-            {openseaError && <Typography>Unable to search wallet for NFTs. Please try again later.</Typography>}
-            {!openseaError && !loadingNfts && (
+            {error && <Typography>{error} Please try again later.</Typography>}
+            {!error && !loadingNfts && (
               <>
                 {nfts.length > 0 ? (
                   <>

--- a/app/src/screens/SelectNFTSection.tsx
+++ b/app/src/screens/SelectNFTSection.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useState, useCallback } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
 import { useENS } from '../ENSProvider';
 import NFTSelectorCloudPure from '../NFTSelectorCloudPure';
@@ -18,7 +18,7 @@ export default function SelectNFTSection() {
   const isMoWeb = useIsMoWeb();
   const [avatar, setAvatar] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
-  const { address } = useWallet();
+  const { address, loadingNfts, nfts, openseaError } = useWallet();
   const { user } = useUser();
   const { name, setAvatar: setEnsAvatar } = useENS();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,12 +70,23 @@ export default function SelectNFTSection() {
 
           <ENSDisplay />
 
-          {name && (
-            <View style={[styles.spaced, isMoWeb && styles.spacedXS]}>
-              <Typography>Select NFT or upload image</Typography>
-              <NFTSelectorCloudPure selectedIndex={nftIndex} onSelect={setNft} />
-            </View>
-          )}
+          <View style={[styles.spaced, isMoWeb && styles.spacedXS]}>
+            {loadingNfts && <ActivityIndicator size={24} />}
+            {openseaError && <Typography>Unable to search wallet for NFTs. Please try again later.</Typography>}
+            {!openseaError && !loadingNfts && (
+              <>
+                {nfts.length > 0 ? (
+                  <>
+                    <Typography>Select NFT or upload image</Typography>
+                    <NFTSelectorCloudPure selectedIndex={nftIndex} onSelect={setNft} nfts={nfts} />
+                  </>
+                ) : (
+                  <Typography>No available NFTs found in your wallet.</Typography>
+                )}
+                )
+              </>
+            )}
+          </View>
         </View>
       </PageContainer>
 


### PR DESCRIPTION
Adds some messaging around different states of the application:

1. Displays user-friendly message when opensea call fails
2. Displays user-friendly message when no NFTs are found in wallet
3. Displays loading indicator when `loadingNfts` is `true`

Currently when the opensea fetch fails the app doesn't display anything useful